### PR TITLE
Remove task timeline help UI and session planning

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-ce4f0d5f'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.4vjegpii9sg"
+    "revision": "0.rnthq5c5cd"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/components/TaskInput.tsx
+++ b/src/components/TaskInput.tsx
@@ -266,42 +266,6 @@ const TaskInput: React.FC<TaskInputProps> = ({ onAddTask, onCancel, userSettings
   // Handle category custom
   const showCustomCategory = formData.category === 'Custom...';
 
-  // Calculate smart session distribution based on deadline pressure
-  const sessionDistribution = useMemo(() => {
-    if (!formData.deadline || formData.deadlineType === 'none') {
-      return {
-        suggestedFrequency: 'relaxed',
-        description: 'Sessions will be distributed based on available time slots',
-        sessions: sessionCalculation.estimatedSessions
-      };
-    }
-
-    const startDate = new Date(formData.startDate || new Date().toISOString().split('T')[0]);
-    const deadlineDate = new Date(formData.deadline);
-    const timeDiff = deadlineDate.getTime() - startDate.getTime();
-    const daysUntilDeadline = Math.ceil(timeDiff / (1000 * 60 * 60 * 24));
-
-    let suggestedFrequency;
-    let description;
-
-    if (daysUntilDeadline < 7) {
-      suggestedFrequency = 'urgent';
-      description = 'Daily sessions recommended due to urgent deadline';
-    } else if (daysUntilDeadline < 14) {
-      suggestedFrequency = 'moderate';
-      description = 'Every other day sessions recommended';
-    } else {
-      suggestedFrequency = 'relaxed';
-      description = '2-3 sessions per week recommended';
-    }
-
-    return {
-      suggestedFrequency,
-      description,
-      sessions: sessionCalculation.estimatedSessions,
-      daysAvailable: daysUntilDeadline
-    };
-  }, [formData.deadline, formData.deadlineType, formData.startDate, sessionCalculation]);
 
   // Enhanced validation with better error messages
   const isTitleValid = formData.title.trim().length > 0;

--- a/src/components/TaskInput.tsx
+++ b/src/components/TaskInput.tsx
@@ -145,27 +145,7 @@ const TaskInput: React.FC<TaskInputProps> = ({ onAddTask, onCancel, userSettings
     }
   }, [formData.deadline]);
 
-  // Reset conflicting options when one-sitting task is toggled
-  useEffect(() => {
-    if (formData.isOneTimeTask) {
-      // One-sitting tasks use the total time as session duration
-      const totalHours = parseFloat(formData.estimatedHours || '0') + parseFloat(formData.estimatedMinutes || '0') / 60;
-      setFormData(f => ({ ...f, sessionDuration: totalHours || 2 }));
-    }
-  }, [formData.isOneTimeTask, formData.estimatedHours, formData.estimatedMinutes]);
 
-  // Calculate estimated sessions based on total time and session duration
-  const sessionCalculation = useMemo(() => {
-    const totalHours = parseFloat(formData.totalTimeNeeded || formData.estimatedHours || '0') + parseFloat(formData.estimatedMinutes || '0') / 60;
-    const sessionDuration = formData.sessionDuration || 2;
-    const estimatedSessions = Math.ceil(totalHours / sessionDuration);
-
-    return {
-      totalHours,
-      sessionDuration,
-      estimatedSessions
-    };
-  }, [formData.totalTimeNeeded, formData.estimatedHours, formData.estimatedMinutes, formData.sessionDuration]);
 
   // Check if form is valid for submission
   const isFormInvalid = useMemo(() => {
@@ -432,9 +412,8 @@ const TaskInput: React.FC<TaskInputProps> = ({ onAddTask, onCancel, userSettings
       // New fields for deadline flexibility
       deadlineType: formData.deadline ? formData.deadlineType : 'none',
       schedulingPreference: formData.schedulingPreference,
-      // Session-based estimation properties
-      sessionDuration: formData.sessionDuration,
-      totalTimeNeeded: parseFloat(formData.totalTimeNeeded || '0') || undefined,
+      // Maximum session length for no-deadline tasks
+      maxSessionLength: formData.maxSessionLength,
       isOneTimeTask: formData.isOneTimeTask,
       startDate: formData.startDate || today,
     });
@@ -450,8 +429,6 @@ const TaskInput: React.FC<TaskInputProps> = ({ onAddTask, onCancel, userSettings
       taskType: '',
       deadlineType: 'hard',
       schedulingPreference: 'consistent',
-      sessionDuration: 2, // Default 2 hours per session
-      totalTimeNeeded: '',
       maxSessionLength: 2,
       isOneTimeTask: false,
       startDate: today,
@@ -574,68 +551,6 @@ const TaskInput: React.FC<TaskInputProps> = ({ onAddTask, onCancel, userSettings
               )}
             </div>
 
-            {/* Session-Based Estimation */}
-            {!formData.isOneTimeTask && (
-              <div className="mt-4">
-                <label className="block text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
-                  Session Planning
-                </label>
-
-                <div className="space-y-3">
-                  {/* Session Duration Input */}
-                  <div>
-                    <label className="block text-xs font-medium text-gray-700 dark:text-gray-200 mb-1">
-                      Preferred session duration
-                    </label>
-                    <div className="flex items-center gap-2">
-                      <input
-                        type="number"
-                        value={formData.sessionDuration}
-                        onChange={e => setFormData(f => ({ ...f, sessionDuration: parseFloat(e.target.value) || 2 }))}
-                        min="0.5"
-                        max="8"
-                        step="0.5"
-                        className="w-20 px-2 py-1 border rounded text-sm bg-white dark:bg-gray-800 dark:text-white"
-                      />
-                      <span className="text-sm text-gray-600 dark:text-gray-400">hours per session</span>
-                    </div>
-                  </div>
-
-                  {/* Alternative Total Time Input */}
-                  <div>
-                    <label className="block text-xs font-medium text-gray-700 dark:text-gray-200 mb-1">
-                      Total time needed (optional alternative to estimation above)
-                    </label>
-                    <div className="flex items-center gap-2">
-                      <input
-                        type="number"
-                        value={formData.totalTimeNeeded}
-                        onChange={e => setFormData(f => ({ ...f, totalTimeNeeded: e.target.value }))}
-                        placeholder="e.g., 12"
-                        min="0"
-                        step="0.5"
-                        className="w-24 px-2 py-1 border rounded text-sm bg-white dark:bg-gray-800 dark:text-white"
-                      />
-                      <span className="text-sm text-gray-600 dark:text-gray-400">total hours</span>
-                    </div>
-                  </div>
-
-                  {/* Session Calculation Display */}
-                  {sessionCalculation.totalHours > 0 && (
-                    <div className="p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg">
-                      <div className="text-sm font-medium text-blue-800 dark:text-blue-200 mb-1">
-                        📅 Session Plan Preview
-                      </div>
-                      <div className="text-xs text-blue-700 dark:text-blue-300">
-                        <div>• {sessionCalculation.estimatedSessions} sessions of {sessionCalculation.sessionDuration}h each</div>
-                        <div>• Total: {sessionCalculation.totalHours}h</div>
-                        <div className="mt-1 font-medium">{sessionDistribution.description}</div>
-                      </div>
-                    </div>
-                  )}
-                </div>
-              </div>
-            )}
 
             {/* Task Timeline Toggle Button */}
             <div className="mt-4">
@@ -734,54 +649,28 @@ const TaskInput: React.FC<TaskInputProps> = ({ onAddTask, onCancel, userSettings
                     </label>
                   </div>
 
-                  {/* Session-based estimation for all tasks */}
-                  <div className="space-y-3 p-3 bg-blue-50 dark:bg-blue-900/30 rounded-lg border border-blue-200 dark:border-blue-700">
-                    <div>
-                      <label className="block text-xs font-medium text-gray-700 dark:text-gray-200 mb-1">Session duration</label>
-                      <div className="flex items-center gap-2">
-                        <input
-                          type="number"
-                          value={formData.sessionDuration}
-                          onChange={e => setFormData(f => ({ ...f, sessionDuration: parseFloat(e.target.value) || 2 }))}
-                          min="0.5"
-                          max="8"
-                          step="0.5"
-                          className="w-20 px-2 py-1 border rounded text-sm bg-white dark:bg-gray-800 dark:text-white"
-                        />
-                        <span className="text-xs text-gray-600 dark:text-gray-400">hours per session</span>
+                  {/* Maximum session length field for no-deadline tasks */}
+                  {formData.deadlineType === 'none' && (
+                    <div className="space-y-3 p-3 bg-blue-50 dark:bg-blue-900/30 rounded-lg border border-blue-200 dark:border-blue-700">
+                      <div>
+                        <label className="block text-xs font-medium text-gray-700 dark:text-gray-200 mb-1">
+                          Maximum session length
+                          <span className="text-gray-500 text-xs ml-1">(for tasks with no deadline but distributed into sessions)</span>
+                        </label>
+                        <select
+                          value={formData.maxSessionLength || 2}
+                          onChange={e => setFormData(f => ({ ...f, maxSessionLength: parseFloat(e.target.value) }))}
+                          className="w-full px-2 py-1 border rounded text-sm bg-white dark:bg-gray-800 dark:text-white"
+                        >
+                          <option value={1}>1 hour</option>
+                          <option value={1.5}>1.5 hours</option>
+                          <option value={2}>2 hours</option>
+                          <option value={3}>3 hours</option>
+                          <option value={4}>4 hours</option>
+                        </select>
                       </div>
                     </div>
-
-                    {/* Total time alternative input */}
-                    <div>
-                      <label className="block text-xs font-medium text-gray-700 dark:text-gray-200 mb-1">Total time needed (optional)</label>
-                      <div className="flex items-center gap-2">
-                        <input
-                          type="number"
-                          value={formData.totalTimeNeeded}
-                          onChange={e => setFormData(f => ({ ...f, totalTimeNeeded: e.target.value }))}
-                          placeholder="e.g., 12"
-                          min="0"
-                          step="0.5"
-                          className="w-24 px-2 py-1 border rounded text-sm bg-white dark:bg-gray-800 dark:text-white"
-                        />
-                        <span className="text-xs text-gray-600 dark:text-gray-400">total hours</span>
-                      </div>
-                    </div>
-
-                    {/* Session calculation display */}
-                    {sessionCalculation.totalHours > 0 && (
-                      <div className="p-2 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-700 rounded text-xs">
-                        <div className="font-medium text-green-800 dark:text-green-200">
-                          📅 {sessionCalculation.estimatedSessions} sessions × {sessionCalculation.sessionDuration}h = {sessionCalculation.totalHours}h total
-                        </div>
-                        <div className="text-green-700 dark:text-green-300 mt-1">
-                          {sessionDistribution.description}
-                        </div>
-                      </div>
-                    )}
-
-                  </div>
+                  )}
                 </div>
               )}
             </div>

--- a/src/components/TaskInputSimplified.tsx
+++ b/src/components/TaskInputSimplified.tsx
@@ -38,7 +38,6 @@ const TaskInputSimplified: React.FC<TaskInputProps> = ({ onAddTask, onCancel, us
   
   // Quick time presets
   const [showTimePresets, setShowTimePresets] = useState(false);
-  const [showSessionPresets, setShowSessionPresets] = useState(false);
   const timePresets = [
     { label: '15m', hours: '0', minutes: '15' },
     { label: '30m', hours: '0', minutes: '30' },
@@ -47,15 +46,6 @@ const TaskInputSimplified: React.FC<TaskInputProps> = ({ onAddTask, onCancel, us
     { label: '1h 30m', hours: '1', minutes: '30' },
     { label: '2h', hours: '2', minutes: '0' },
     { label: '3h', hours: '3', minutes: '0' },
-  ];
-
-  const sessionPresets = [
-    { label: '15m', hours: '0', minutes: '15' },
-    { label: '30m', hours: '0', minutes: '30' },
-    { label: '45m', hours: '0', minutes: '45' },
-    { label: '1h', hours: '1', minutes: '0' },
-    { label: '1h 30m', hours: '1', minutes: '30' },
-    { label: '2h', hours: '2', minutes: '0' },
   ];
 
   // Auto-detect deadline type based on whether deadline is set

--- a/src/components/TaskInputSimplified.tsx
+++ b/src/components/TaskInputSimplified.tsx
@@ -529,177 +529,91 @@ const TaskInputSimplified: React.FC<TaskInputProps> = ({ onAddTask, onCancel, us
               </label>
             </div>
 
-            {formData.estimationMode === 'total' ? (
-              <div className="space-y-2">
-                <div className="flex items-center space-x-3">
-                  <div className="flex-1 p-3 border border-white/30 dark:border-white/20 rounded-xl bg-white/70 dark:bg-black/20">
-                    <div className="flex items-center justify-between">
-                      <div className="text-lg font-medium text-gray-800 dark:text-white">
-                        {totalTime > 0 ? formatTimeDisplay(formData.estimatedHours, formData.estimatedMinutes) : 'Not set'}
-                      </div>
-                      <div className="flex items-center gap-2">
-                        {formData.estimatedHours && (
-                          <button
-                            type="button"
-                            aria-label="Clear hours"
-                            title="Clear hours"
-                            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
-                            onClick={() => setFormData(f => ({ ...f, estimatedHours: '' }))}
-                          >
-                            <X size={16} />
-                          </button>
-                        )}
-                        {(formData.estimatedMinutes && formData.estimatedMinutes !== '0') && (
-                          <button
-                            type="button"
-                            aria-label="Clear minutes"
-                            title="Clear minutes"
-                            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
-                            onClick={() => setFormData(f => ({ ...f, estimatedMinutes: '0' }))}
-                          >
-                            <X size={16} />
-                          </button>
-                        )}
-                      </div>
+            <div className="space-y-2">
+              <div className="flex items-center space-x-3">
+                <div className="flex-1 p-3 border border-white/30 dark:border-white/20 rounded-xl bg-white/70 dark:bg-black/20">
+                  <div className="flex items-center justify-between">
+                    <div className="text-lg font-medium text-gray-800 dark:text-white">
+                      {totalTime > 0 ? formatTimeDisplay(formData.estimatedHours, formData.estimatedMinutes) : 'Not set'}
                     </div>
-                    {formData.taskType && (
-                      <div className="text-sm text-gray-600 dark:text-gray-400">
-                        Task type: {formData.taskType}
-                      </div>
-                    )}
-                  </div>
-                  <button
-                    type="button"
-                    onClick={() => setShowTimeEstimationModal(true)}
-                    className="flex items-center space-x-2 px-4 py-3 bg-violet-600 hover:bg-violet-700 text-white rounded-xl transition-colors"
-                  >
-                    <Clock size={18} />
-                    <span>Estimate</span>
-                  </button>
-                </div>
-                <div className="flex items-center gap-4 text-xs">
-                  <button
-                    type="button"
-                    onClick={() => setShowTimeEstimationModal(true)}
-                    className="text-violet-600 dark:text-violet-400 hover:underline"
-                  >
-                    Need help estimating?
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setShowTimePresets(!showTimePresets)}
-                    className="text-violet-600 dark:text-violet-400 hover:underline"
-                  >
-                    {showTimePresets ? 'Hide quick presets' : 'Show quick presets'}
-                  </button>
-                </div>
-                {showTimePresets && (
-                  <div className="mt-1">
-                    <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">Quick presets:</div>
-                    <div className="flex flex-wrap gap-1">
-                      {timePresets.map((preset, index) => (
-                        <button
-                          key={index}
-                          type="button"
-                          onClick={() => setFormData(f => ({
-                            ...f,
-                            estimatedHours: preset.hours,
-                            estimatedMinutes: preset.minutes,
-                          }))}
-                          className="px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-white rounded border transition-colors"
-                        >
-                          {preset.label}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
-            ) : (
-              <div className="space-y-3">
-                <div className="p-3 border border-white/30 dark:border-white/20 rounded-xl bg-white/70 dark:bg-black/20">
-                  <div className="flex items-center justify-between mb-2">
-                    <div className="text-sm font-medium text-gray-700 dark:text-gray-200">Session Duration</div>
                     <div className="flex items-center gap-2">
-                      {formData.sessionDurationHours && (
+                      {formData.estimatedHours && (
                         <button
                           type="button"
-                          aria-label="Clear session hours"
-                          title="Clear session hours"
+                          aria-label="Clear hours"
+                          title="Clear hours"
                           className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
-                          onClick={() => setFormData(f => ({ ...f, sessionDurationHours: '' }))}
+                          onClick={() => setFormData(f => ({ ...f, estimatedHours: '' }))}
+                        >
+                          <X size={16} />
+                        </button>
+                      )}
+                      {(formData.estimatedMinutes && formData.estimatedMinutes !== '0') && (
+                        <button
+                          type="button"
+                          aria-label="Clear minutes"
+                          title="Clear minutes"
+                          className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+                          onClick={() => setFormData(f => ({ ...f, estimatedMinutes: '0' }))}
                         >
                           <X size={16} />
                         </button>
                       )}
                     </div>
                   </div>
-                  <div className="flex items-center gap-3 mb-2">
-                    <div className="flex items-center gap-2">
-                      <input
-                        type="number"
-                        value={formData.sessionDurationHours}
-                        onChange={e => setFormData(f => ({ ...f, sessionDurationHours: e.target.value }))}
-                        className="w-16 px-2 py-1 text-sm border border-white/30 dark:border-white/20 rounded bg-white/70 dark:bg-black/20 dark:text-white focus:ring-2 focus:ring-violet-500"
-                        placeholder="0"
-                        min="0"
-                        max="8"
-                      />
-                      <span className="text-sm text-gray-600 dark:text-gray-300">h</span>
+                  {formData.taskType && (
+                    <div className="text-sm text-gray-600 dark:text-gray-400">
+                      Task type: {formData.taskType}
                     </div>
-                    <div className="flex items-center gap-2">
-                      <input
-                        type="number"
-                        value={formData.sessionDurationMinutes}
-                        onChange={e => setFormData(f => ({ ...f, sessionDurationMinutes: e.target.value }))}
-                        className="w-16 px-2 py-1 text-sm border border-white/30 dark:border-white/20 rounded bg-white/70 dark:bg-black/20 dark:text-white focus:ring-2 focus:ring-violet-500"
-                        placeholder="0"
-                        min="0"
-                        max="59"
-                        step="5"
-                      />
-                      <span className="text-sm text-gray-600 dark:text-gray-300">m</span>
-                    </div>
-                    <div className="text-sm text-gray-600 dark:text-gray-300">per session</div>
-                  </div>
+                  )}
                 </div>
-                <div className="flex items-center gap-4 text-xs">
-                  <button
-                    type="button"
-                    onClick={() => setShowSessionPresets(!showSessionPresets)}
-                    className="text-violet-600 dark:text-violet-400 hover:underline"
-                  >
-                    {showSessionPresets ? 'Hide session presets' : 'Show session presets'}
-                  </button>
-                </div>
-                {showSessionPresets && (
-                  <div className="mt-1">
-                    <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">Common session durations:</div>
-                    <div className="flex flex-wrap gap-1">
-                      {sessionPresets.map((preset, index) => (
-                        <button
-                          key={index}
-                          type="button"
-                          onClick={() => setFormData(f => ({
-                            ...f,
-                            sessionDurationHours: preset.hours,
-                            sessionDurationMinutes: preset.minutes,
-                          }))}
-                          className="px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-white rounded border transition-colors"
-                        >
-                          {preset.label}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-                {formData.estimationMode === 'session' && (!formData.deadline || formData.deadlineType === 'none') && (
-                  <div className="p-2 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-700 rounded text-xs text-yellow-700 dark:text-yellow-200">
-                    Session-based estimation requires a deadline to calculate total time.
-                  </div>
-                )}
+                <button
+                  type="button"
+                  onClick={() => setShowTimeEstimationModal(true)}
+                  className="flex items-center space-x-2 px-4 py-3 bg-violet-600 hover:bg-violet-700 text-white rounded-xl transition-colors"
+                >
+                  <Clock size={18} />
+                  <span>Estimate</span>
+                </button>
               </div>
-            )}
+              <div className="flex items-center gap-4 text-xs">
+                <button
+                  type="button"
+                  onClick={() => setShowTimeEstimationModal(true)}
+                  className="text-violet-600 dark:text-violet-400 hover:underline"
+                >
+                  Need help estimating?
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowTimePresets(!showTimePresets)}
+                  className="text-violet-600 dark:text-violet-400 hover:underline"
+                >
+                  {showTimePresets ? 'Hide quick presets' : 'Show quick presets'}
+                </button>
+              </div>
+              {showTimePresets && (
+                <div className="mt-1">
+                  <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">Quick presets:</div>
+                  <div className="flex flex-wrap gap-1">
+                    {timePresets.map((preset, index) => (
+                      <button
+                        key={index}
+                        type="button"
+                        onClick={() => setFormData(f => ({
+                          ...f,
+                          estimatedHours: preset.hours,
+                          estimatedMinutes: preset.minutes,
+                        }))}
+                        className="px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-white rounded border transition-colors"
+                      >
+                        {preset.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
           </div>
 
           {/* 8. Task Importance */}

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -28,7 +28,6 @@ const TaskList: React.FC<TaskListProps> = ({ tasks, onUpdateTask, onDeleteTask, 
   const [editFormData, setEditFormData] = useState<EditFormData>({});
   const [showCompletedTasks, setShowCompletedTasks] = useState(false);
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
-  const [showHelpModal, setShowHelpModal] = useState(false);
   const [showTimeEstimationModal, setShowTimeEstimationModal] = useState(false);
 
   // Sorting state with localStorage persistence
@@ -551,16 +550,8 @@ const TaskList: React.FC<TaskListProps> = ({ tasks, onUpdateTask, onDeleteTask, 
 
                       {showAdvancedOptions && (
                         <div className="mt-3 p-4 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-600">
-                          <div className="flex items-center gap-2 mb-3">
+                          <div className="mb-3">
                             <span className="text-sm font-medium text-gray-700 dark:text-gray-200">Task Timeline Options</span>
-                            <button
-                              type="button"
-                              onClick={() => setShowHelpModal(true)}
-                              className="text-gray-400 hover:text-blue-600 transition-colors"
-                              title="Help & Information"
-                            >
-                              <HelpCircle size={16} />
-                            </button>
                           </div>
 
 
@@ -881,65 +872,6 @@ const TaskList: React.FC<TaskListProps> = ({ tasks, onUpdateTask, onDeleteTask, 
         </div>
       )}
 
-      {/* Help Modal */}
-      {showHelpModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-2xl max-h-96 overflow-y-auto m-4">
-            <div className="flex justify-between items-center mb-4">
-              <h3 className="text-lg font-semibold text-gray-800 dark:text-white">Task Timeline Help</h3>
-              <button
-                onClick={() => setShowHelpModal(false)}
-                className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
-              >
-                
-              </button>
-            </div>
-
-            <div className="space-y-4 text-sm text-gray-600 dark:text-gray-300">
-              <div>
-                <h4 className="font-medium text-gray-800 dark:text-white mb-2">Timeline Options Explained:</h4>
-
-                <div className="space-y-3">
-                  <div>
-                    <strong className="text-blue-600 dark:text-blue-400">Hard Deadline:</strong>
-                    <p>Task must be completed by the specified date. The app will prioritize these tasks and schedule them with urgency.</p>
-                  </div>
-
-                  <div>
-                    <strong className="text-green-600 dark:text-green-400">Flexible Target:</strong>
-                    <p>You have a goal date but it's not critical. The app will try to finish by this date but may extend if needed.</p>
-                  </div>
-
-                  <div>
-                    <strong className="text-purple-600 dark:text-purple-400">No Deadline:</strong>
-                    <p>Perfect for learning, hobbies, and personal development. The app schedules these tasks in available time slots without pressure.</p>
-                  </div>
-                </div>
-              </div>
-
-              <div>
-                <h4 className="font-medium text-gray-800 dark:text-white mb-2">Task Importance & Scheduling Priority:</h4>
-                <div className="space-y-2">
-                  <div>
-                    <strong className="text-red-600 dark:text-red-400">High Impact Tasks:</strong>
-                    <p>Always scheduled first, regardless of deadline type. These tasks significantly affect your success and commitments.</p>
-                  </div>
-                  <div>
-                    <strong className="text-gray-600 dark:text-gray-400">Low Impact Tasks:</strong>
-                    <p>Scheduled after high impact tasks. Will be moved or postponed if schedule becomes tight.</p>
-                  </div>
-                </div>
-              </div>
-
-              <div className="bg-blue-50 dark:bg-blue-900/30 p-3 rounded-lg">
-                <p className="text-blue-800 dark:text-blue-200">
-                  <strong>Tip:</strong> Use high impact for tasks that significantly affect your goals, and low impact for routine or optional tasks!
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
 
       {/* Time Estimation Help Modal */}
       {showTimeEstimationModal && (

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -565,66 +565,28 @@ const TaskList: React.FC<TaskListProps> = ({ tasks, onUpdateTask, onDeleteTask, 
 
 
 
-                          {/* Additional options for deadline tasks */}
-                          <div className="space-y-3 p-3 bg-blue-50 dark:bg-blue-900/30 rounded-lg border border-blue-200 dark:border-blue-700">
-                            <div>
-                              <label className="flex items-center gap-2 text-xs font-medium text-gray-700 dark:text-gray-200 mb-1">
-                                <input
-                                  type="checkbox"
-                                  checked={editFormData.respectFrequencyForDeadlines !== false}
-                                  onChange={(e) => setEditFormData({ ...editFormData, respectFrequencyForDeadlines: e.target.checked })}
-                                  className="text-blue-600"
-                                />
-                                Respect frequency preference for deadline tasks
-                              </label>
-                              <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                                Uncheck to allow daily scheduling for urgent deadline tasks regardless of frequency preference
+                          {/* Additional preferences for no-deadline tasks */}
+                          {editFormData.deadlineType === 'none' && (
+                            <div className="space-y-3 p-3 bg-blue-50 dark:bg-blue-900/30 rounded-lg border border-blue-200 dark:border-blue-700">
+                              <div>
+                                <label className="block text-xs font-medium text-gray-700 dark:text-gray-200 mb-1">
+                                  Maximum session length
+                                  <span className="text-gray-500 text-xs ml-1">(for tasks with no deadline but distributed into sessions)</span>
+                                </label>
+                                <select
+                                  value={editFormData.maxSessionLength || 2}
+                                  onChange={(e) => setEditFormData({ ...editFormData, maxSessionLength: parseInt(e.target.value) })}
+                                  className="w-full px-2 py-1 border rounded text-sm bg-white dark:bg-gray-800 dark:text-white"
+                                >
+                                  <option value={1}>1 hour</option>
+                                  <option value={1.5}>1.5 hours</option>
+                                  <option value={2}>2 hours</option>
+                                  <option value={3}>3 hours</option>
+                                  <option value={4}>4 hours</option>
+                                </select>
                               </div>
                             </div>
-
-                            {/* Additional preferences for no-deadline tasks */}
-                            {editFormData.deadlineType === 'none' && (
-                              <>
-                                <div>
-                                  <label className="block text-xs font-medium text-gray-700 dark:text-gray-200 mb-1">Preferred time</label>
-                                  <div className="flex gap-2">
-                                    {['morning', 'afternoon', 'evening'].map(timeSlot => (
-                                      <label key={timeSlot} className="flex items-center gap-1">
-                                        <input
-                                          type="checkbox"
-                                          checked={(editFormData.preferredTimeSlots || []).includes(timeSlot as any)}
-                                          onChange={(e) => {
-                                            const timeSlots = editFormData.preferredTimeSlots || [];
-                                            if (e.target.checked) {
-                                              setEditFormData({ ...editFormData, preferredTimeSlots: [...timeSlots, timeSlot as any] });
-                                            } else {
-                                              setEditFormData({ ...editFormData, preferredTimeSlots: timeSlots.filter(t => t !== timeSlot) });
-                                            }
-                                          }}
-                                        />
-                                        <span className="capitalize text-xs text-gray-700 dark:text-gray-300">{timeSlot}</span>
-                                      </label>
-                                    ))}
-                                  </div>
-                                </div>
-
-                                <div>
-                                  <label className="block text-xs font-medium text-gray-700 dark:text-gray-200 mb-1">Maximum session length</label>
-                                  <select
-                                    value={editFormData.maxSessionLength || 2}
-                                    onChange={(e) => setEditFormData({ ...editFormData, maxSessionLength: parseInt(e.target.value) })}
-                                    className="w-full px-2 py-1 border rounded text-sm bg-white dark:bg-gray-800 dark:text-white"
-                                  >
-                                    <option value={1}>1 hour</option>
-                                    <option value={1.5}>1.5 hours</option>
-                                    <option value={2}>2 hours</option>
-                                    <option value={3}>3 hours</option>
-                                    <option value={4}>4 hours</option>
-                                  </select>
-                                </div>
-                              </>
-                            )}
-                          </div>
+                          )}
                         </div>
                       )}
                     </div>

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -469,129 +469,46 @@ const TaskList: React.FC<TaskListProps> = ({ tasks, onUpdateTask, onDeleteTask, 
 
                     {/* 7. Time Estimation - Dual Mode Interface */}
                     <div>
-                      <div className="flex items-center justify-between mb-2">
-                        <div className="flex items-center gap-2">
-                          <label className="block text-sm font-semibold text-gray-700 dark:text-gray-200">
-                            Time Estimation <span className="text-red-500">*</span>
-                          </label>
-                          <button
-                            type="button"
-                            onClick={() => setShowTimeEstimationModal(true)}
-                            className="text-gray-400 hover:text-blue-600 transition-colors"
-                            title="How does time estimation work?"
-                          >
-                            <HelpCircle size={14} />
-                          </button>
-                        </div>
-                        {!editFormData.isOneTimeTask && (
-                          <div className="flex bg-white/50 dark:bg-black/30 rounded-lg p-1 border border-gray-200 dark:border-gray-600">
-                            <button
-                              type="button"
-                              onClick={() => setEditFormData(prev => ({ ...prev, estimationMode: 'total' }))}
-                              className={`px-3 py-1 text-xs rounded-md transition-colors ${
-                                (editFormData.estimationMode || 'total') === 'total'
-                                  ? 'bg-blue-600 text-white shadow-sm'
-                                  : 'text-gray-600 dark:text-gray-300 hover:bg-white/50 dark:hover:bg-black/30'
-                              }`}
-                            >
-                              Total Time
-                            </button>
-                            <button
-                              type="button"
-                              onClick={() => setEditFormData(prev => ({ ...prev, estimationMode: 'session' }))}
-                              className={`px-3 py-1 text-xs rounded-md transition-colors ${
-                                editFormData.estimationMode === 'session'
-                                  ? 'bg-blue-600 text-white shadow-sm'
-                                  : 'text-gray-600 dark:text-gray-300 hover:bg-white/50 dark:hover:bg-black/30'
-                              }`}
-                            >
-                              Session-Based
-                            </button>
-                          </div>
-                        )}
+                      <div className="flex items-center gap-2 mb-2">
+                        <label className="block text-sm font-semibold text-gray-700 dark:text-gray-200">
+                          Time Estimation <span className="text-red-500">*</span>
+                        </label>
+                        <button
+                          type="button"
+                          onClick={() => setShowTimeEstimationModal(true)}
+                          className="text-gray-400 hover:text-blue-600 transition-colors"
+                          title="How does time estimation work?"
+                        >
+                          <HelpCircle size={14} />
+                        </button>
                       </div>
 
-                      {(editFormData.estimationMode || 'total') === 'total' ? (
-                        // Total Time Mode (existing)
-                        <div className="flex gap-2 items-center">
-                          <div className="flex-1">
-                            <input
-                              type="number"
-                              min="0"
-                              value={editFormData.estimatedHours || ''}
-                              onChange={(e) => setEditFormData({ ...editFormData, estimatedHours: parseInt(e.target.value) || 0 })}
-                              className="w-full border rounded-lg px-3 py-2 text-base focus:ring-2 focus:ring-blue-500 focus:border-transparent border-gray-300 bg-white dark:bg-gray-800 dark:text-white"
-                              placeholder="0"
-                            />
-                            <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">Hours</div>
-                          </div>
-                          <div className="text-gray-500 dark:text-gray-400 text-lg font-bold">:</div>
-                          <div className="flex-1">
-                            <input
-                              type="number"
-                              min="0"
-                              max="59"
-                              value={editFormData.estimatedMinutes || ''}
-                              onChange={(e) => setEditFormData({ ...editFormData, estimatedMinutes: parseInt(e.target.value) || 0 })}
-                              className="w-full border rounded-lg px-3 py-2 text-base focus:ring-2 focus:ring-blue-500 focus:border-transparent border-gray-300 bg-white dark:bg-gray-800 dark:text-white"
-                              placeholder="0"
-                            />
-                            <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">Minutes</div>
-                          </div>
+                      <div className="flex gap-2 items-center">
+                        <div className="flex-1">
+                          <input
+                            type="number"
+                            min="0"
+                            value={editFormData.estimatedHours || ''}
+                            onChange={(e) => setEditFormData({ ...editFormData, estimatedHours: parseInt(e.target.value) || 0 })}
+                            className="w-full border rounded-lg px-3 py-2 text-base focus:ring-2 focus:ring-blue-500 focus:border-transparent border-gray-300 bg-white dark:bg-gray-800 dark:text-white"
+                            placeholder="0"
+                          />
+                          <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">Hours</div>
                         </div>
-                      ) : (
-                        // Session-Based Mode (new)
-                        <div className="space-y-3">
-                          <div className="p-3 border border-gray-200 dark:border-gray-600 rounded-lg bg-gray-50 dark:bg-gray-700">
-                            <div className="text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">Session Duration</div>
-                            <div className="flex items-center gap-3 mb-2">
-                              <div className="flex items-center gap-2">
-                                <input
-                                  type="number"
-                                  value={editFormData.sessionDurationHours || ''}
-                                  onChange={e => setEditFormData(prev => ({ ...prev, sessionDurationHours: e.target.value }))}
-                                  className="w-16 px-2 py-1 text-sm border rounded bg-white dark:bg-gray-800 dark:text-white focus:ring-2 focus:ring-blue-500"
-                                  placeholder="0"
-                                  min="0"
-                                  max="8"
-                                />
-                                <span className="text-sm text-gray-600 dark:text-gray-300">h</span>
-                              </div>
-                              <div className="flex items-center gap-2">
-                                <input
-                                  type="number"
-                                  value={editFormData.sessionDurationMinutes || ''}
-                                  onChange={e => setEditFormData(prev => ({ ...prev, sessionDurationMinutes: e.target.value }))}
-                                  className="w-16 px-2 py-1 text-sm border rounded bg-white dark:bg-gray-800 dark:text-white focus:ring-2 focus:ring-blue-500"
-                                  placeholder="0"
-                                  min="0"
-                                  max="59"
-                                  step="5"
-                                />
-                                <span className="text-sm text-gray-600 dark:text-gray-300">m</span>
-                              </div>
-                              <div className="text-sm text-gray-600 dark:text-gray-300">per session</div>
-                            </div>
-                            {calculateSessionBasedTotal > 0 && (
-                              <div className="text-sm text-gray-600 dark:text-gray-400 bg-blue-50 dark:bg-blue-900/20 rounded p-2">
-                                <div className="font-medium">
-                                  Calculated total: {Math.floor(calculateSessionBasedTotal)}h {Math.round((calculateSessionBasedTotal % 1) * 60)}m
-                                </div>
-                                <div className="text-xs mt-1">
-                                  Based on {editFormData.targetFrequency === 'daily' ? 'daily' :
-                                          editFormData.targetFrequency === '3x-week' ? '3x per week' :
-                                          editFormData.targetFrequency === 'weekly' ? 'weekly' : 'flexible'} frequency until deadline
-                                </div>
-                              </div>
-                            )}
-                          </div>
-                          {editFormData.estimationMode === 'session' && (!editFormData.deadline || editFormData.deadlineType === 'none') && (
-                            <div className="p-2 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-700 rounded text-xs text-yellow-700 dark:text-yellow-200">
-                              Session-based estimation requires a deadline to calculate total time.
-                            </div>
-                          )}
+                        <div className="text-gray-500 dark:text-gray-400 text-lg font-bold">:</div>
+                        <div className="flex-1">
+                          <input
+                            type="number"
+                            min="0"
+                            max="59"
+                            value={editFormData.estimatedMinutes || ''}
+                            onChange={(e) => setEditFormData({ ...editFormData, estimatedMinutes: parseInt(e.target.value) || 0 })}
+                            className="w-full border rounded-lg px-3 py-2 text-base focus:ring-2 focus:ring-blue-500 focus:border-transparent border-gray-300 bg-white dark:bg-gray-800 dark:text-white"
+                            placeholder="0"
+                          />
+                          <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">Minutes</div>
                         </div>
-                      )}
+                      </div>
                     </div>
 
                     {/* 8. Task Importance */}

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { BookOpen, Edit, Trash2, CheckCircle2, X, Info, ChevronDown, ChevronUp, HelpCircle, ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react';
+import { BookOpen, Edit, Trash2, CheckCircle2, X, Info, ChevronDown, ChevronUp, ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react';
 import { Task, UserSettings } from '../types';
 import { formatTime, calculateSessionDistribution } from '../utils/scheduling';
 


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR removes the task timeline help UI and simplifies the task editing interface. The users requested removal of the task timeline help UI and wanted to streamline the task edit experience by eliminating complex session planning features.

## Code changes

- **Removed session-based estimation logic**: Eliminated `sessionCalculation`, `sessionDistribution`, and related useEffect hooks that handled session duration calculations
- **Simplified task form data**: Removed `sessionDuration` and `totalTimeNeeded` fields, replaced with simpler `maxSessionLength` for no-deadline tasks
- **Removed help modal**: Completely removed the task timeline help modal component and its associated state management
- **Streamlined UI**: Removed session planning section from task input form, including session duration inputs and session plan preview
- **Cleaned up task edit form**: Simplified the task timeline options section, removing complex deadline-specific controls and help button
- **Updated service worker**: Bumped revision hash for cache invalidation

The changes focus on simplifying the user experience by removing overly complex session planning features while maintaining core functionality for task management.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/68677047879145aa8b7b69ce627da92e/pulse-realm)

👀 [Preview Link](https://68677047879145aa8b7b69ce627da92e-pulse-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>68677047879145aa8b7b69ce627da92e</projectId>-->
<!--<branchName>pulse-realm</branchName>-->